### PR TITLE
PHPH81 : Remove deprecated FILTER_SANITIZE_STRING

### DIFF
--- a/WorkFrame/Libraries/Security.php
+++ b/WorkFrame/Libraries/Security.php
@@ -61,7 +61,8 @@ class Security {
 			}
 		}
 		else {
-			$v = filter_var($v, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW|FILTER_FLAG_STRIP_HIGH|FILTER_FLAG_STRIP_BACKTICK|FILTER_FLAG_NO_ENCODE_QUOTES);
+			$v = preg_replace('/<[^>]*>?/', '', $v); // strip full and partial tags
+			$v = filter_var($v, FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW|FILTER_FLAG_STRIP_HIGH|FILTER_FLAG_STRIP_BACKTICK);
 		}
 		return $v;
 	}


### PR DESCRIPTION
Quick php8.1 deprecated fix.
Replaced FILTER_SANITIZE_STRING with FILTER_UNSAFE_RAW (similar flags) and additional preg_replace for filtering out tags / partial tags + content